### PR TITLE
Fix code scanning alert no. 1: Incomplete URL scheme check

### DIFF
--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -47,7 +47,9 @@ export const getPermalink = (slug = '', type = 'page'): string => {
     slug.startsWith('http://') ||
     slug.startsWith('://') ||
     slug.startsWith('#') ||
-    slug.startsWith('javascript:')
+    slug.startsWith('javascript:') ||
+    slug.startsWith('data:') ||
+    slug.startsWith('vbscript:')
   ) {
     return slug;
   }


### PR DESCRIPTION
Fixes incomplete URL scheme check

To fix the problem, we need to extend the existing URL scheme check to include `data:` and `vbscript:` schemes. This involves modifying the conditional statement that currently checks for `javascript:` to also check for `data:` and `vbscript:`. This change should be made in the `getPermalink` function within the `src/utils/permalinks.ts` file.
